### PR TITLE
Use slider instead of button to Deactivate Pod

### DIFF
--- a/OmniKitUI/ViewModels/DeactivatePodViewModel.swift
+++ b/OmniKitUI/ViewModels/DeactivatePodViewModel.swift
@@ -52,7 +52,7 @@ class DeactivatePodViewModel: ObservableObject, Identifiable {
         var actionButtonDescription: String {
             switch self {
             case .active:
-                return LocalizedString("Deactivate Pod", comment: "Action button description for deactivate while pod still active")
+                return LocalizedString("Slide to Deactivate Pod", comment: "Action button description for deactivate while pod still active")
             case .resultError:
                 return LocalizedString("Retry", comment: "Action button description for deactivate after failed attempt")
             case .deactivating:
@@ -111,6 +111,14 @@ class DeactivatePodViewModel: ObservableObject, Identifiable {
     }
     
     @Published var state: DeactivatePodViewModelState = .active
+    public var stateNeedsDeliberateUserAcceptance : Bool {
+        switch state {
+        case .active:
+            true
+        default:
+            false
+        }
+    }
 
     var error: DeactivationError? {
         if case .resultError(let error) = self.state {

--- a/OmniKitUI/Views/DeactivatePodView.swift
+++ b/OmniKitUI/Views/DeactivatePodView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 import LoopKitUI
+import SlideButton
 
 struct DeactivatePodView: View {
     
@@ -65,15 +66,8 @@ struct DeactivatePodView: View {
                     }
                     .disabled(viewModel.state.isProcessing)
                 }
-                Button(action: {
-                    viewModel.continueButtonTapped()
-                }) {
-                    Text(viewModel.state.actionButtonDescription)
-                        .accessibility(identifier: "button_next_action")
-                        .accessibility(label: Text(viewModel.state.actionButtonAccessibilityLabel))
-                        .actionButtonStyle(viewModel.state.actionButtonStyle)
-                }
-                .disabled(viewModel.state.isProcessing)
+                actionButton
+                    .disabled(viewModel.state.isProcessing)
             }
             .padding()
         }
@@ -94,4 +88,30 @@ struct DeactivatePodView: View {
             secondaryButton: .default(FrameworkLocalText("Continue", comment: "Title of button to continue discard"), action: { viewModel.discardPod() })
         )
     }
+    
+    var actionText: some View {
+        Text(self.viewModel.state.actionButtonDescription)
+            .accessibility(identifier: "button_next_action")
+            .accessibility(label: Text(self.viewModel.state.actionButtonAccessibilityLabel))
+            .font(.headline)
+    }
+    
+    @ViewBuilder
+    var actionButton: some View {
+        if self.viewModel.stateNeedsDeliberateUserAcceptance {
+            SlideButton(styling: .init(indicatorSize: 60, indicatorColor: Color.red), action: {
+                self.viewModel.continueButtonTapped()
+            }) {
+                actionText
+            }
+        } else {
+            Button(action: {
+                self.viewModel.continueButtonTapped()
+            }) {
+                actionText
+                    .actionButtonStyle(.primary)
+            }
+        }
+    }
+
 }

--- a/OmniKitUI/Views/DeactivatePodView.swift
+++ b/OmniKitUI/Views/DeactivatePodView.swift
@@ -103,7 +103,7 @@ struct DeactivatePodView: View {
                 self.viewModel.continueButtonTapped()
             }) {
                 actionText
-            }
+            }.environment(\.layoutDirection, .leftToRight)
         } else {
             Button(action: {
                 self.viewModel.continueButtonTapped()

--- a/OmniKitUI/Views/DeactivatePodView.swift
+++ b/OmniKitUI/Views/DeactivatePodView.swift
@@ -103,7 +103,7 @@ struct DeactivatePodView: View {
                 self.viewModel.continueButtonTapped()
             }) {
                 actionText
-            }.environment(\.layoutDirection, .leftToRight)
+            }
         } else {
             Button(action: {
                 self.viewModel.continueButtonTapped()


### PR DESCRIPTION
Edited to says - updated now that PR #13 was merged.

I started with @dabear InsertCannulaViewImprovementsOmniKit branch for PR #13.
I merged main into my branch (InsertCannula_Deactivate_ViewImprovements) and then added the same modifications as were used for OmniBLE but to the OmniKit files.

I tested this with an Eros pod on my desktop. Insert Cannula and Deactivate pod both present a slider instead of a button.
Graphics are the same as for OmniBLE PR 102.

Both the insert slide and deactivate slider worked as expected.

