### PR TITLE
update so cannula insert slider works for right to left languages

### DIFF
--- a/OmniKitUI/Views/InsertCannulaView.swift
+++ b/OmniKitUI/Views/InsertCannulaView.swift
@@ -96,7 +96,7 @@ struct InsertCannulaView: View {
                 self.viewModel.continueButtonTapped()
             }) {
                 actionText
-            }
+            }.environment(\.layoutDirection, .leftToRight)
 
         } else {
             Button(action: {


### PR DESCRIPTION
This solves the problem with the cannula insertion slider for right to left languages reported in [Loop Issue 2105](https://github.com/LoopKit/Loop/issues/2105)