### PR TITLE
add missing addStatusObserver to pendingCommandRecovery

### DIFF
--- a/OmniKitUI/ViewControllers/OmnipodUICoordinator.swift
+++ b/OmniKitUI/ViewControllers/OmnipodUICoordinator.swift
@@ -307,6 +307,7 @@ class OmnipodUICoordinator: UINavigationController, PumpManagerOnboarding, Compl
                         self.completionDelegate?.completionNotifyingDidComplete(self)
                     }
                 }
+                pumpManager.addStatusObserver(model, queue: DispatchQueue.main)
                 pumpManager.getPodStatus() { _ in }
 
                 let handleRileyLinkSelection = { [weak self] (device: RileyLinkDevice) in


### PR DESCRIPTION
See Loop Issue https://github.com/LoopKit/Loop/issues/2118 for description of the problem.

By comparing the OmniBLE DashUICoordinator.swift file and the OmniKit OmnipodUICoordinator.swift file, I observed a line missing in the OmniKit version.

By adding that line and repeating the Uncertain Comms test for Eros, I was able to demonstrate immediate recovery for Eros similar to that seen when testing with the DASH rPi for OmniBLE.

In other words:
* Stimulate an uncertain comms using Eros pod, Medtronic Rileylink and Faraday bag
* With this PR in place, when the Rileylink is removed from the Faraday bag, the Comms restored screen appeared immediately