### PR TITLE
enable user to set another expiration reminder for current pod

### DIFF
--- a/OmniKitUI/Views/NotificationSettingsView.swift
+++ b/OmniKitUI/Views/NotificationSettingsView.swift
@@ -66,20 +66,16 @@ struct NotificationSettingsView: View {
     
     private func scheduledReminderRow(scheduledDate: Date?, allowedDates: [Date]) -> some View {
         Group {
-            if let scheduledDate = scheduledDate, scheduledDate <= Date() {
-                scheduledReminderRowContents(disclosure: false)
-            } else {
-                NavigationLink(
-                    destination: ScheduledExpirationReminderEditView(
-                        scheduledExpirationReminderDate: scheduledDate,
-                        allowedDates: allowedDates,
-                        dateFormatter: dateFormatter,
-                        onSave: onSaveScheduledExpirationReminder,
-                        onFinish: { scheduleReminderDateEditViewIsShown = false }),
-                    isActive: $scheduleReminderDateEditViewIsShown)
-                {
-                    scheduledReminderRowContents(disclosure: true)
-                }
+            NavigationLink(
+                destination: ScheduledExpirationReminderEditView(
+                    scheduledExpirationReminderDate: scheduledDate,
+                    allowedDates: allowedDates,
+                    dateFormatter: dateFormatter,
+                    onSave: onSaveScheduledExpirationReminder,
+                    onFinish: { scheduleReminderDateEditViewIsShown = false }),
+                isActive: $scheduleReminderDateEditViewIsShown)
+            {
+                scheduledReminderRowContents(disclosure: true)
             }
         }
     }

--- a/OmniKitUI/Views/NotificationSettingsView.swift
+++ b/OmniKitUI/Views/NotificationSettingsView.swift
@@ -42,7 +42,7 @@ struct NotificationSettingsView: View {
 
             if let allowedDates = allowedScheduledReminderDates {
                 RoundedCard(
-                    footer: LocalizedString("This is a reminder that you scheduled when you paired your current Pod.", comment: "Footer text for scheduled reminder area"))
+                    footer: LocalizedString("This is a reminder that you scheduled for your current Pod.", comment: "Footer text for scheduled reminder area"))
                 {
                     Text(LocalizedString("Scheduled Reminder", comment: "Scheduled reminder card title on NotificationSettingsView"))
                     Divider()


### PR DESCRIPTION
This change enables a user to set a reminder for a later time if an expiration reminder has happened.

For example, default reminder might be 24 hours, but after being reminded, the user might want to set another reminder for 12 hours later.

This modification enables the user to take this action.