### PR TITLE
Fix pairing issue introduced in pr 28

### DIFF
--- a/OmniKitUI/ViewModels/PairPodViewModel.swift
+++ b/OmniKitUI/ViewModels/PairPodViewModel.swift
@@ -193,7 +193,10 @@ class PairPodViewModel: ObservableObject, Identifiable {
             DispatchQueue.main.async {
                 switch status {
                 case .failure(let error):
-                    if self.autoRetryAttempted {
+                    if self.podPairer.podCommState == .noPod {
+                        let pairAndPrimeError = OmnipodPairingError.pumpManagerError(error)
+                        self.state = .error(pairAndPrimeError)
+                    } else if self.autoRetryAttempted {
                         self.autoRetryAttempted = false // allow for an auto retry on the next user attempt
                         let pairAndPrimeError = OmnipodPairingError.pumpManagerError(error)
                         self.state = .error(pairAndPrimeError)


### PR DESCRIPTION
Problem being solved:
* Please see https://github.com/LoopKit/Loop/issues/2154

Test performed with test phone with Omnipod pump (but no pod):
* If no pod is present, selecting Pair Pod returns the No Pod found message promptly
