### PR TITLE
Fix handling of comms error on resume & all pod DeliveryStatus cases

### DIFF
--- a/OmniKit/OmnipodCommon/Pod.swift
+++ b/OmniKit/OmnipodCommon/Pod.swift
@@ -99,22 +99,25 @@ public struct Pod {
 }
 
 // DeliveryStatus used in StatusResponse and DetailedStatus
+// Since bits 1 & 2 are exclusive and bits 4 & 8 are exclusive,
+// these are all the possible values that can be returned.
 public enum DeliveryStatus: UInt8, CustomStringConvertible {
     case suspended = 0
     case scheduledBasal = 1
     case tempBasalRunning = 2
-    case priming = 4
+    case priming = 4 // bolusing while suspended, should only occur during priming
     case bolusInProgress = 5
     case bolusAndTempBasal = 6
+    case extendedBolusWhileSuspended = 8 // should never occur
     case extendedBolusRunning = 9
     case extendedBolusAndTempBasal = 10
 
     public var suspended: Bool {
-        return self == .suspended
+        return self == .suspended || self == .priming || self == .extendedBolusWhileSuspended
     }
 
     public var bolusing: Bool {
-        return self == .bolusInProgress || self == .bolusAndTempBasal || self == .extendedBolusRunning || self == .extendedBolusAndTempBasal
+        return self == .bolusInProgress || self == .bolusAndTempBasal || self == .extendedBolusRunning || self == .extendedBolusAndTempBasal || self == .priming || self == .extendedBolusWhileSuspended
     }
 
     public var tempBasalRunning: Bool {
@@ -122,7 +125,7 @@ public enum DeliveryStatus: UInt8, CustomStringConvertible {
     }
 
     public var extendedBolusRunning: Bool {
-        return self == .extendedBolusRunning || self == .extendedBolusAndTempBasal
+        return self == .extendedBolusRunning || self == .extendedBolusAndTempBasal || self == .extendedBolusWhileSuspended
     }
 
     public var description: String {
@@ -139,6 +142,8 @@ public enum DeliveryStatus: UInt8, CustomStringConvertible {
             return LocalizedString("Bolusing", comment: "Delivery status when bolusing")
         case .bolusAndTempBasal:
             return LocalizedString("Bolusing with temp basal", comment: "Delivery status when bolusing and temp basal is running")
+        case .extendedBolusWhileSuspended:
+            return LocalizedString("Extended bolus running while suspended", comment: "Delivery status when extended bolus is running while suspended")
         case .extendedBolusRunning:
             return LocalizedString("Extended bolus running", comment: "Delivery status when extended bolus is running")
         case .extendedBolusAndTempBasal:

--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -1864,7 +1864,7 @@ extension OmnipodPumpManager: PumpManager {
                 state.bolusEngageState = .engaging
             })
 
-            if case .some(.suspended) = self.state.podState?.suspendState {
+            if let podState = self.state.podState, podState.isSuspended || podState.lastDeliveryStatusReceived?.suspended != false {
                 self.log.error("enactBolus: returning pod suspended error for bolus")
                 completion(.deviceState(PodCommsError.podSuspended))
                 return
@@ -2003,7 +2003,7 @@ extension OmnipodPumpManager: PumpManager {
                 return
             }
 
-            if case (.suspended) = podState.suspendState {
+            if let podState = self.state.podState, podState.isSuspended || podState.lastDeliveryStatusReceived?.suspended != false {
                 self.log.info("Not enacting temp basal because podState indicates pod is suspended.")
                 completion(.deviceState(PodCommsError.podSuspended))
                 return
@@ -2512,7 +2512,9 @@ extension OmnipodPumpManager {
             if alert.alertIdentifier == alertIdentifier || alert.repeatingAlertIdentifier == alertIdentifier {
                 // If this alert was triggered by the pod find the slot to clear it.
                 if let slot = alert.triggeringSlot {
-                    if case .some(.suspended) = self.state.podState?.suspendState, slot == .slot6SuspendTimeExpired {
+                    if (self.state.podState?.isSuspended == true || self.state.podState?.lastDeliveryStatusReceived?.suspended == true) &&
+                        slot == .slot6SuspendTimeExpired
+                    {
                         // Don't clear this pod alert here with the pod still suspended so that the suspend time expired
                         // pod alert beeping will continue until the pod is resumed which will then deactivate this alert.
                         log.default("Skipping acknowledgement of suspend time expired alert with a suspended pod")

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -777,7 +777,9 @@ public class PodCommsSession {
                     let _: StatusResponse = try send([CancelDeliveryCommand(nonce: podState.currentNonce, deliveryType: .all, beepType: .noBeepCancel)])
                 }
             }
+            podState.unacknowledgedCommand = PendingCommand.program(.basalProgram(schedule: schedule), transport.messageNumber, currentDate)
             var status: StatusResponse = try send([basalScheduleCommand, basalExtraCommand])
+            podState.unacknowledgedCommand = nil
             let now = currentDate
             podState.suspendState = .resumed(now)
             podState.unfinalizedResume = UnfinalizedDose(resumeStartTime: now, scheduledCertainty: .certain, insulinType: podState.insulinType)
@@ -788,12 +790,12 @@ public class PodCommsSession {
             }
             podState.updateFromStatusResponse(status, at: currentDate)
             return status
-        } catch PodCommsError.nonceResyncFailed {
-            throw PodCommsError.nonceResyncFailed
-        } catch PodCommsError.rejectedMessage(let errorCode) {
-            throw PodCommsError.rejectedMessage(errorCode: errorCode)
+        } catch PodCommsError.unacknowledgedMessage(let seq, let error) {
+            podState.unacknowledgedCommand = podState.unacknowledgedCommand?.commsFinished
+            log.error("Unacknowledged resume: command seq = %d, error = %{public}@", seq, String(describing: error))
+            throw error
         } catch let error {
-            podState.unfinalizedResume = UnfinalizedDose(resumeStartTime: currentDate, scheduledCertainty: .uncertain, insulinType: podState.insulinType)
+            podState.unacknowledgedCommand = nil
             throw error
         }
     }


### PR DESCRIPTION
This PR uses code changes from @itsmojo to address [Trio Issue 244: Critical Pod Fault 049 (0x31) Error When Resuming Insulin Delivery](https://github.com/nightscout/Trio/issues/244#top)

See also [Loop Issue 2121: Bug Report: Eros Pod Fault of 0x31 (-049)](https://github.com/LoopKit/Loop/issues/2121#top), specifically [this comment](https://github.com/LoopKit/Loop/issues/2121#issuecomment-2140997758) 