### PR TITLE
update podState, add setStateWithResult to match OmniBLE, from itsmojo

### DIFF
--- a/OmniKit/PumpManager/OmnipodPumpManagerState.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManagerState.swift
@@ -67,6 +67,8 @@ public struct OmnipodPumpManagerState: RawRepresentable, Equatable {
 
     internal var tempBasalEngageState: EngageablePumpState = .stable
 
+    internal var lastStatusChange: Date = .distantPast
+
     internal var lastPumpDataReportDate: Date?
     
     internal var insulinType: InsulinType?


### PR DESCRIPTION
This PR is in response to a problem found in Trio, which uses the same submodules as Loop. The code difference was prepared and tested by @itsmojo.

Loop works fine without these changes, but also should continue to work.

When modifying OmniKit in a manner similar to OmniBLE (https://github.com/LoopKit/OmniBLE/pull/125), it was discovered some code found in OmniBLE did not make it into OmniKit when that code was updated to SwiftUI. 

From @itsmojo:
* "I think that this was just an accidental omission and that the OmniKit setStateWithResult should match the OmniBLE version which takes time into consideration when looking for changes between oldStatus & newStatus as well as oldHighlight and newHighlight."

Trio Issue: [Extra messages exchanged with Omnipod](https://github.com/nightscout/Trio/issues/265)