### PR TITLE
Update logic to prevent bogus suspend error after comms error

### DIFF
--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -1870,8 +1870,8 @@ extension OmnipodPumpManager: PumpManager {
                 state.bolusEngageState = .engaging
             })
 
-            if let podState = self.state.podState, podState.isSuspended || podState.lastDeliveryStatusReceived?.suspended != false {
-                self.log.error("enactBolus: returning pod suspended error for bolus")
+            if let podState = self.state.podState, podState.isSuspended || podState.lastDeliveryStatusReceived?.suspended == true {
+                self.log.error("Not enacting bolus because podState or last status received indicates pod is suspended")
                 completion(.deviceState(PodCommsError.podSuspended))
                 return
             }
@@ -2009,8 +2009,8 @@ extension OmnipodPumpManager: PumpManager {
                 return
             }
 
-            if let podState = self.state.podState, podState.isSuspended || podState.lastDeliveryStatusReceived?.suspended != false {
-                self.log.info("Not enacting temp basal because podState indicates pod is suspended.")
+            if let podState = self.state.podState, podState.isSuspended || podState.lastDeliveryStatusReceived?.suspended == true {
+                self.log.info("Not enacting temp basal because podState or last status received indicates pod is suspended")
                 completion(.deviceState(PodCommsError.podSuspended))
                 return
             }

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -527,6 +527,11 @@ public class PodCommsSession {
                     log.default("bolus: pod is still bolusing")
                     return DeliveryCommandResult.certainFailure(error: .unfinalizedBolus)
                 }
+                // If the pod setup is complete, also confirm that the pod is indeed not suspended
+                if podState.setupProgress == .completed && statusResponse.deliveryStatus.suspended {
+                    log.default("bolus: pod is suspended")
+                    return DeliveryCommandResult.certainFailure(error: .podSuspended)
+                }
             } else {
                 log.default("bolus: failed to read pod status to verify there is no bolus running")
                 return DeliveryCommandResult.certainFailure(error: .noResponse)


### PR DESCRIPTION
This fixes Loop Issue 2198 [Bug: Incorrect pod suspended message when bolusing after comms error](https://github.com/LoopKit/Loop/issues/2198#top) 