### PR TITLE
Fix for perpetual Insert Cannula "Pod Already Paired" errors

### DIFF
--- a/OmniKitUI/ViewModels/InsertCannulaViewModel.swift
+++ b/OmniKitUI/ViewModels/InsertCannulaViewModel.swift
@@ -189,7 +189,7 @@ class InsertCannulaViewModel: ObservableObject, Identifiable {
                     }
                 case .failure(let error):
                     if case .podAlreadyPaired = error {
-                        print("### insertCannula treating podAlreadyPaired as success to avoid looping!")
+                        print("### insertCannula treating podAlreadyPaired as success")
                         self.state = .finished
                     } else if self.autoRetryAttempted {
                         self.autoRetryAttempted = false // allow for an auto retry on the next user attempt

--- a/OmniKitUI/ViewModels/InsertCannulaViewModel.swift
+++ b/OmniKitUI/ViewModels/InsertCannulaViewModel.swift
@@ -130,6 +130,7 @@ class InsertCannulaViewModel: ObservableObject, Identifiable {
     }
 
     @Published var state: InsertCannulaViewModelState = .ready
+
     public var stateNeedsDeliberateUserAcceptance : Bool {
         switch state {
         case .ready:
@@ -187,7 +188,10 @@ class InsertCannulaViewModel: ObservableObject, Identifiable {
                         self.state = .finished
                     }
                 case .failure(let error):
-                    if self.autoRetryAttempted {
+                    if case .podAlreadyPaired = error {
+                        print("### insertCannula treating podAlreadyPaired as success to avoid looping!")
+                        self.state = .finished
+                    } else if self.autoRetryAttempted {
                         self.autoRetryAttempted = false // allow for an auto retry on the next user attempt
                         self.state = .error(error)
                     } else {

--- a/OmniKitUI/Views/InsertCannulaView.swift
+++ b/OmniKitUI/Views/InsertCannulaView.swift
@@ -69,12 +69,14 @@ struct InsertCannulaView: View {
                 if (self.viewModel.error == nil || self.viewModel.error?.recoverable == true) {
                     actionButton
                     .disabled(self.viewModel.state.isProcessing)
+                    .animation(nil)
                     .zIndex(1)
                 }
             }
             .transition(AnyTransition.opacity.combined(with: .move(edge: .bottom)))
             .padding()
         }
+        .animation(.default)
         .alert(isPresented: $cancelModalIsPresented) { cancelPairingModal }
         .navigationBarTitle(LocalizedString("Insert Cannula", comment: "navigation bar title for insert cannula"), displayMode: .automatic)
         .navigationBarBackButtonHidden(true)
@@ -107,8 +109,6 @@ struct InsertCannulaView: View {
             }
 
         }
-
-
     }
 
     
@@ -131,9 +131,23 @@ struct InsertCannulaView: View {
 }
 
 class MockCannulaInserter: CannulaInserter {
+    let mockError: Bool = false
+    let mockPodAlreadyPairedError: Bool = false
+
     func insertCannula(completion: @escaping (Result<TimeInterval,OmnipodPumpManagerError>) -> Void) {
-        let mockDelay = TimeInterval(seconds: 3)
-        let result :Result<TimeInterval, OmnipodPumpManagerError> = .success(mockDelay)
+        let result :Result<TimeInterval, OmnipodPumpManagerError>
+        if mockError {
+            if mockPodAlreadyPairedError {
+                // A podAlreadyPaired "error" should be treated as an immediate success
+                result = .failure(OmnipodPumpManagerError.podAlreadyPaired)
+            } else {
+                // Others should display the error text and show Deactivate Pod & Retry options
+                result = .failure(OmnipodPumpManagerError.noPodPaired)
+            }
+        } else {
+            let mockDelay = TimeInterval(seconds: 3)
+            result = .success(mockDelay)
+        }
         completion(result)
     }
 


### PR DESCRIPTION
This rare event happened with Trio but could potentially happen with Loop or iAPS as the code involved is virtually identical in all cases. The straightforward logic modification will prevent being forever stuck in the Insert Cannula screen with a Pod Already Paired error in the future. See https://github.com/nightscout/Trio/issues/380 for additional info.
+ Add optional mock error Preview handling code
+ Minor updates to match OmniBLE versions