### PR TITLE
Prevent Deactivate Pod card from being dismissed with a sideways pull

### DIFF
--- a/OmniKitUI/Views/DeactivatePodView.swift
+++ b/OmniKitUI/Views/DeactivatePodView.swift
@@ -73,6 +73,7 @@ struct DeactivatePodView: View {
         }
         .alert(isPresented: $removePodModalIsPresented) { removePodModal }
         .navigationBarTitle(LocalizedString("Deactivate Pod", comment: "navigation bar title for deactivate pod"), displayMode: .automatic)
+        .navigationBarBackButtonHidden(true)
         .navigationBarItems(trailing:
             Button("Cancel") {
                 viewModel.didCancel?()


### PR DESCRIPTION
## Background

A pod is deactivated by dragging a slider across the screen. It is really easy to miss where your finger is placed and drag the whole card - which dismisses that screen.

The Insert Cannula screen has a similar slider and does not get dismissed accidentally.

When I compared Insert and Deactivate code side by side, the Insert Cannula hides the back button but the Deactivate Pod does not. Adding that line to Deactivate solves the issue of discarding the Deactivate screen inadvertently.

The user can still discard that screen by tapping Cancel or pulling down from the top.

## Test

This was tested using an Eros pod. It was paired and cannula was inserted. The Deactivate screen was evaluated by trying to drag sideways. The card is no longer dismissed. This was tested with right-to-left as well as left-to-right language selected.