### PR TITLE
return clock icon when isClockOffset is true - fix for main branch

### DIFF
--- a/OmniKitUI/PumpManager/OmniPodPumpManager+UI.swift
+++ b/OmniKitUI/PumpManager/OmniPodPumpManager+UI.swift
@@ -47,6 +47,24 @@ extension OmnipodPumpManager: PumpManagerUI {
 
 }
 
+public enum OmniKitStatusBadge: DeviceStatusBadge {
+    case timeSyncNeeded
+
+    public var image: UIImage? {
+        switch self {
+        case .timeSyncNeeded:
+            return UIImage(systemName: "clock.fill")
+        }
+    }
+
+    public var state: DeviceStatusBadgeState {
+        switch self {
+        case .timeSyncNeeded:
+            return .warning
+        }
+    }
+}
+
 // MARK: - PumpStatusIndicator
 extension OmnipodPumpManager {
     public var pumpStatusHighlight: DeviceStatusHighlight? {
@@ -58,7 +76,10 @@ extension OmnipodPumpManager {
     }
     
     public var pumpStatusBadge: DeviceStatusBadge? {
-        return nil
+        if isClockOffset {
+            return OmniKitStatusBadge.timeSyncNeeded
+        } else {
+            return nil
+        }
     }
-
 }


### PR DESCRIPTION
This PR is identical to PR #43 but against the main branch.

It adds the clock icon for the main screen when using Eros pods and the pod time zone does not match the phone time zone.