### PR TITLE
Fix for pump manager returns bogus podSuspended

### DIFF
--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -1141,7 +1141,7 @@ extension OmnipodPumpManager {
             case .success(let session):
                 do {
                     if let error = self.tryToValidateComms(session: session) {
-                        completion(.state(error))
+                        completion(.communication(error))
                         return
                     }
 
@@ -1503,7 +1503,7 @@ extension OmnipodPumpManager {
             }
 
             if let error = self.tryToValidateComms(session: session) {
-                completion(.state(error))
+                completion(.communication(error))
                 return
             }
 
@@ -1922,7 +1922,7 @@ extension OmnipodPumpManager: PumpManager {
             })
 
             if let error = self.tryToValidateComms(session: session) {
-                completion(.deviceState(error))
+                completion(.communication(error))
                 return
             }
 
@@ -2068,7 +2068,7 @@ extension OmnipodPumpManager: PumpManager {
             }
 
             if let error = self.tryToValidateComms(session: session) {
-                completion(.deviceState(PumpManagerError.deviceState(error)))
+                completion(.communication(error))
                 return
             }
 


### PR DESCRIPTION
## Purpose

This PR fixes a problem reported by Trio users [Trio Issue 468](https://github.com/nightscout/Trio/issues/468) in which the pump manager can sometimes report podSuspended following an uncertain comm event.

## Background

An earlier PR #47 added one improvement for automatically recovering from uncertain comms but increased the incidence of the podSuspended being returned from the pump manager when the pod was not actually suspended.

## Proposed Solution

This PR adds tryToValidateComms which, if successful, enables the pump manager to return the updated response from getStatus.

It also modifies some guard statements so that a podSuspended is only returned when the last message received from the pod indicates the pod is actually suspended.

The goal is to have the PumpManager return the true pod status, if possible.