### PR TITLE
Update OmniKit tidepool-merge with improvements from main

### DIFF
--- a/OmniKit.xcodeproj/project.pbxproj
+++ b/OmniKit.xcodeproj/project.pbxproj
@@ -8,6 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		275A98C02AE456EA0097F476 /* SlideButton in Frameworks */ = {isa = PBXBuildFile; productRef = 275A98BF2AE456EA0097F476 /* SlideButton */; };
+		3B0FD2A12D803BB000E5E921 /* RileyLinkBLEKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B0FD2A02D803BB000E5E921 /* RileyLinkBLEKit.framework */; };
+		3B0FD2A32D803BB800E5E921 /* RileyLinkKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B0FD2A22D803BB800E5E921 /* RileyLinkKit.framework */; };
+		3B0FD2A62D803C2000E5E921 /* OmniKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C124016C29C7D87A00B32844 /* OmniKit.framework */; };
+		3B0FD2A82D803C2C00E5E921 /* RileyLinkKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B0FD2A72D803C2C00E5E921 /* RileyLinkKitUI.framework */; };
 		B60BB2EC2BC757A700D2BB39 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60BB2EA2BC7579E00D2BB39 /* Bundle.swift */; };
 		C1229C1A29C7E5BC0066A89C /* RileyLinkBLEKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1229C1729C7E5BC0066A89C /* RileyLinkBLEKit.framework */; };
 		C1229C1B29C7E5BC0066A89C /* RileyLinkBLEKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C1229C1729C7E5BC0066A89C /* RileyLinkBLEKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -192,6 +196,7 @@
 		D80339982A50085C004FF953 /* TimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12EDA0329C7DDC800435701 /* TimeInterval.swift */; };
 		D803399A2A500D3D004FF953 /* CRC8.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12401B229C7D8E900B32844 /* CRC8.swift */; };
 		D803399B2A50122F004FF953 /* Packet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12401B329C7D8E900B32844 /* Packet.swift */; };
+		D803399C2A50128D004FF953 /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12EDA0129C7DD4700435701 /* LocalizedString.swift */; };
 		D845A1352AF89DEC00EA0853 /* SilencePodPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = D845A1342AF89DEC00EA0853 /* SilencePodPreference.swift */; };
 		D845A1462AF8A4DA00EA0853 /* ActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D845A1452AF8A4DA00EA0853 /* ActivityView.swift */; };
 		D845A14A2AF8A4EF00EA0853 /* PlayTestBeepsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D845A1492AF8A4EF00EA0853 /* PlayTestBeepsView.swift */; };
@@ -200,7 +205,6 @@
 		D845A1522AF8A51000EA0853 /* SilencePodSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D845A1512AF8A51000EA0853 /* SilencePodSelectionView.swift */; };
 		D85AEAC82B1403C000081044 /* PodDiagnosticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85AEAC72B1403C000081044 /* PodDiagnosticsView.swift */; };
 		D85AEACA2B1403CB00081044 /* ReadPodInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85AEAC92B1403CB00081044 /* ReadPodInfoView.swift */; };
-		D803399C2A50128D004FF953 /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12EDA0129C7DD4700435701 /* LocalizedString.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -255,6 +259,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3B0FD2A02D803BB000E5E921 /* RileyLinkBLEKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RileyLinkBLEKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3B0FD2A22D803BB800E5E921 /* RileyLinkKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RileyLinkKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3B0FD2A72D803C2C00E5E921 /* RileyLinkKitUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RileyLinkKitUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B60BB2EA2BC7579E00D2BB39 /* Bundle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
 		C10E1EE62AE59EDC00B4E993 /* hi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hi; path = hi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C1229C1729C7E5BC0066A89C /* RileyLinkBLEKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RileyLinkBLEKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -467,6 +474,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3B0FD2A32D803BB800E5E921 /* RileyLinkKit.framework in Frameworks */,
+				3B0FD2A12D803BB000E5E921 /* RileyLinkBLEKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -474,6 +483,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3B0FD2A82D803C2C00E5E921 /* RileyLinkKitUI.framework in Frameworks */,
+				3B0FD2A62D803C2000E5E921 /* OmniKit.framework in Frameworks */,
 				275A98C02AE456EA0097F476 /* SlideButton in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -822,6 +833,9 @@
 		C12ED9F329C7DCE100435701 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				3B0FD2A72D803C2C00E5E921 /* RileyLinkKitUI.framework */,
+				3B0FD2A22D803BB800E5E921 /* RileyLinkKit.framework */,
+				3B0FD2A02D803BB000E5E921 /* RileyLinkBLEKit.framework */,
 				C1229C1729C7E5BC0066A89C /* RileyLinkBLEKit.framework */,
 				C1229C1829C7E5BC0066A89C /* RileyLinkKit.framework */,
 				C1229C1929C7E5BC0066A89C /* RileyLinkKitUI.framework */,

--- a/OmniKit/OmnipodCommon/Pod.swift
+++ b/OmniKit/OmnipodCommon/Pod.swift
@@ -53,15 +53,15 @@ public struct Pod {
     public static let reservoirCapacity: Double = 200
 
     // Supported basal rates
-    // Eros minimum scheduled basal rate is 0.05 U/H while for Dash supports 0 U/H.
-    // Would need to have this value based on productID to be able to share this file with DASH.
+    // Eros minimum scheduled basal rate is 0.05 U/H while Dash supports 0 U/H.
     public static let supportedBasalRates: [Double] = (1...600).map { Double($0) / Double(pulsesPerUnit) }
 
     // Supported temp basal rates
+    // Both Eros and Dash support a minimum temp basal rate of 0 U/H.
     public static let supportedTempBasalRates: [Double] = (0...600).map { Double($0) / Double(pulsesPerUnit) }
 
-    // The internal basal rate used for non-Eros pods
-    // Would need to have this value based on productID to be able to share this file with Eros.
+    // The internal basal rate used for zero basal rates
+    // Eros uses 0.0 while Dash uses a near zero rate
     public static let zeroBasalRate: Double = 0.0
 
     // Maximum number of basal schedule entries supported

--- a/OmniKit/OmnipodCommon/Pod.swift
+++ b/OmniKit/OmnipodCommon/Pod.swift
@@ -54,7 +54,7 @@ public struct Pod {
 
     // Supported basal rates
     // Eros minimum scheduled basal rate is 0.05 U/H while for Dash supports 0 U/H.
-    // Would need to have this value based on productID to be able to share this with Eros.
+    // Would need to have this value based on productID to be able to share this file with DASH.
     public static let supportedBasalRates: [Double] = (1...600).map { Double($0) / Double(pulsesPerUnit) }
 
     // Supported temp basal rates
@@ -113,19 +113,46 @@ public enum DeliveryStatus: UInt8, CustomStringConvertible {
     case extendedBolusAndTempBasal = 10
 
     public var suspended: Bool {
-        return self == .suspended || self == .priming || self == .extendedBolusWhileSuspended
+        // returns true if both the tempBasal and basal bits are clear
+        let suspendedStates: Set<DeliveryStatus> = [
+            .suspended,
+            .priming,
+            .extendedBolusWhileSuspended,
+        ]
+        return suspendedStates.contains(self)
     }
 
     public var bolusing: Bool {
-        return self == .bolusInProgress || self == .bolusAndTempBasal || self == .extendedBolusRunning || self == .extendedBolusAndTempBasal || self == .priming || self == .extendedBolusWhileSuspended
+        // returns true if either the immediateBolus or extendedBolus bits are set
+        let bolusingStates: Set<DeliveryStatus> = [
+            .priming,
+            .bolusInProgress,
+            .bolusAndTempBasal,
+            .extendedBolusWhileSuspended,
+            .extendedBolusRunning,
+            .extendedBolusAndTempBasal,
+        ]
+        return bolusingStates.contains(self)
     }
 
     public var tempBasalRunning: Bool {
-        return self == .tempBasalRunning || self == .bolusAndTempBasal || self == .extendedBolusAndTempBasal
+        // returns true if the tempBasal bit is set
+        let tempBasalRunningStates: Set<DeliveryStatus> = [
+            .tempBasalRunning,
+            .bolusAndTempBasal,
+            .extendedBolusAndTempBasal,
+        ]
+        return tempBasalRunningStates.contains(self)
     }
 
     public var extendedBolusRunning: Bool {
-        return self == .extendedBolusRunning || self == .extendedBolusAndTempBasal || self == .extendedBolusWhileSuspended
+        // returns true if the extendedBolus bit is set
+        let extendedBolusRunningStates: Set<DeliveryStatus> = [
+            .extendedBolusWhileSuspended,
+            .extendedBolusRunning,
+            .extendedBolusAndTempBasal,
+        ]
+        return extendedBolusRunningStates.contains(self)
     }
 
     public var description: String {

--- a/OmniKit/OmnipodCommon/Pod.swift
+++ b/OmniKit/OmnipodCommon/Pod.swift
@@ -53,11 +53,11 @@ public struct Pod {
     public static let reservoirCapacity: Double = 200
 
     // Supported basal rates
-    // Eros minimum scheduled basal rate is 0.05 U/H while Dash supports 0 U/H.
+    // Eros minimum scheduled basal rate is 0.05 U/hr while Dash supports 0 U/hr.
     public static let supportedBasalRates: [Double] = (1...600).map { Double($0) / Double(pulsesPerUnit) }
 
     // Supported temp basal rates
-    // Both Eros and Dash support a minimum temp basal rate of 0 U/H.
+    // Both Eros and Dash support a minimum temp basal rate of 0 U/hr.
     public static let supportedTempBasalRates: [Double] = (0...600).map { Double($0) / Double(pulsesPerUnit) }
 
     // The internal basal rate used for zero basal rates

--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -1141,7 +1141,7 @@ extension OmnipodPumpManager {
             case .success(let session):
                 do {
                     if let error = self.tryToValidateComms(session: session) {
-                        completion(.state(error))
+                        completion(.communication(error))
                         return
                     }
 
@@ -1503,7 +1503,7 @@ extension OmnipodPumpManager {
             }
 
             if let error = self.tryToValidateComms(session: session) {
-                completion(.state(error))
+                completion(.communication(error))
                 return
             }
 
@@ -1922,7 +1922,7 @@ extension OmnipodPumpManager: PumpManager {
             })
 
             if let error = self.tryToValidateComms(session: session) {
-                completion(.deviceState(error))
+                completion(.communication(error))
                 return
             }
 
@@ -2068,7 +2068,7 @@ extension OmnipodPumpManager: PumpManager {
             }
 
             if let error = self.tryToValidateComms(session: session) {
-                completion(.deviceState(PumpManagerError.deviceState(error)))
+                completion(.communication(error))
                 return
             }
 

--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -1870,7 +1870,7 @@ extension OmnipodPumpManager: PumpManager {
                 state.bolusEngageState = .engaging
             })
 
-            if let podState = self.state.podState, podState.isSuspended || podState.lastDeliveryStatusReceived?.suspended == true {
+            guard let podState = self.state.podState, !podState.isSuspended && podState.lastDeliveryStatusReceived?.suspended == false else {
                 self.log.info("Not enacting bolus because podState or last status received indicates pod is suspended")
                 completion(.deviceState(PodCommsError.podSuspended))
                 return
@@ -1968,7 +1968,7 @@ extension OmnipodPumpManager: PumpManager {
 
     public func runTemporaryBasalProgram(unitsPerHour: Double, for duration: TimeInterval, automatic: Bool, completion: @escaping (PumpManagerError?) -> Void) {
 
-        guard self.hasActivePod, let podState = self.state.podState else {
+        guard self.hasActivePod else {
             completion(.configuration(OmnipodPumpManagerError.noPodPaired))
             return
         }
@@ -2009,7 +2009,7 @@ extension OmnipodPumpManager: PumpManager {
                 return
             }
 
-            if let podState = self.state.podState, podState.isSuspended || podState.lastDeliveryStatusReceived?.suspended == true {
+            guard let podState = self.state.podState, !podState.isSuspended && podState.lastDeliveryStatusReceived?.suspended == false else {
                 self.log.info("Not enacting temp basal because podState or last status received indicates pod is suspended")
                 completion(.deviceState(PodCommsError.podSuspended))
                 return

--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -2448,12 +2448,10 @@ extension OmnipodPumpManager: PumpManager {
 
 extension OmnipodPumpManager: MessageLogger {
     func didSend(_ message: Data) {
-        log.default("didSend: %{public}@", message.hexadecimalString)
         self.logDeviceCommunication(message.hexadecimalString, type: .send)
     }
     
     func didReceive(_ message: Data) {
-        log.default("didReceive: %{public}@", message.hexadecimalString)
         self.logDeviceCommunication(message.hexadecimalString, type: .receive)
     }
 

--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -1871,7 +1871,7 @@ extension OmnipodPumpManager: PumpManager {
             })
 
             if let podState = self.state.podState, podState.isSuspended || podState.lastDeliveryStatusReceived?.suspended == true {
-                self.log.error("Not enacting bolus because podState or last status received indicates pod is suspended")
+                self.log.info("Not enacting bolus because podState or last status received indicates pod is suspended")
                 completion(.deviceState(PodCommsError.podSuspended))
                 return
             }
@@ -2053,7 +2053,7 @@ extension OmnipodPumpManager: PumpManager {
                     return
                 }
 
-                guard status.deliveryStatus != .suspended else {
+                guard !status.deliveryStatus.suspended else {
                     self.log.info("Canceling temp basal because status return indicates pod is suspended!")
                     completion(.communication(PodCommsError.podSuspended))
                     return

--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -398,26 +398,26 @@ public class PodCommsSession {
     }
 
     //
-    // Attempts to resolve any unacknowledged command by calling getStatus().
+    // Attempts to resolve any pending unacknowledged command by calling getStatus().
     // podState.unacknowledgeCommand is guaranteed to be nil upon successful return.
     // Throws PodCommsError.unacknowledgedCommandPending if unsuccessful for any reason.
     //
-    private func resolveUnacknowledgedCommand() throws {
+    private func tryToResolvePendingCommand() throws {
 
         guard podState.unacknowledgedCommand != nil else {
-            return // no unacknowledged command to resolve
+            return // no pending unacknowledged command to resolve
         }
 
         do {
-            _ = try getStatus() // should resolve the unacknowledged command if successful
+            _ = try getStatus() // should resolve the pending unacknowledged command if successful
         } catch let error {
-            log.error("GetStatus failed trying to resolve unacknowledged command: %{public}@", String(describing: error))
+            log.error("GetStatus failed trying to resolve pending unacknowledged command: %{public}@", String(describing: error))
             throw PodCommsError.unacknowledgedCommandPending
         }
 
-        // Verify that getStatus successfully resolved the unacknowledged command.
+        // Verify that getStatus successfully resolved the pending unacknowledged command.
         guard podState.unacknowledgedCommand == nil else {
-            log.error("Successful getStatus didn't resolve the unacknowledged command!")
+            log.error("Successful getStatus didn't resolve the pending unacknowledged command!")
             throw PodCommsError.unacknowledgedCommandPending
         }
 
@@ -431,7 +431,7 @@ public class PodCommsSession {
     func configureAlerts(_ alerts: [PodAlert], acknowledgeAll: Bool = false, beepBlock: MessageBlock? = nil) throws -> StatusResponse {
 
         if podState.unacknowledgedCommand != nil {
-            try resolveUnacknowledgedCommand()
+            try tryToResolvePendingCommand()
         }
 
         let configurations = alerts.map { $0.configuration }
@@ -461,7 +461,7 @@ public class PodCommsSession {
 
         if podState.unacknowledgedCommand != nil {
             do {
-                try resolveUnacknowledgedCommand()
+                try tryToResolvePendingCommand()
             } catch let error {
                 return .failure(error)
             }
@@ -555,7 +555,7 @@ public class PodCommsSession {
 
         if podState.unacknowledgedCommand != nil {
             do {
-                try resolveUnacknowledgedCommand()
+                try tryToResolvePendingCommand()
             } catch {
                 return DeliveryCommandResult.certainFailure(error: .unacknowledgedCommandPending)
             }
@@ -606,7 +606,7 @@ public class PodCommsSession {
 
         if podState.unacknowledgedCommand != nil {
             do {
-                try resolveUnacknowledgedCommand()
+                try tryToResolvePendingCommand()
             } catch {
                 return DeliveryCommandResult.certainFailure(error: .unacknowledgedCommandPending)
             }
@@ -684,7 +684,7 @@ public class PodCommsSession {
 
         if podState.unacknowledgedCommand != nil {
             do {
-                try resolveUnacknowledgedCommand()
+                try tryToResolvePendingCommand()
             } catch {
                 return .certainFailure(error: .unacknowledgedCommandPending)
             }
@@ -772,7 +772,7 @@ public class PodCommsSession {
 
         if podState.unacknowledgedCommand != nil {
             do {
-                try resolveUnacknowledgedCommand()
+                try tryToResolvePendingCommand()
             } catch {
                 return .certainFailure(error: .unacknowledgedCommandPending)
             }
@@ -806,7 +806,7 @@ public class PodCommsSession {
     public func setTime(timeZone: TimeZone, basalSchedule: BasalSchedule, date: Date, acknowledgementBeep: Bool = false) throws -> StatusResponse {
 
         if podState.unacknowledgedCommand != nil {
-            try resolveUnacknowledgedCommand()
+            try tryToResolvePendingCommand()
         }
 
         let result = cancelDelivery(deliveryType: .all)
@@ -825,7 +825,7 @@ public class PodCommsSession {
     public func setBasalSchedule(schedule: BasalSchedule, scheduleOffset: TimeInterval, acknowledgementBeep: Bool = false, programReminderInterval: TimeInterval = 0) throws -> StatusResponse {
 
         if podState.unacknowledgedCommand != nil {
-            try resolveUnacknowledgedCommand()
+            try tryToResolvePendingCommand()
         }
 
         let basalScheduleCommand = SetInsulinScheduleCommand(nonce: podState.currentNonce, basalSchedule: schedule, scheduleOffset: scheduleOffset)
@@ -866,7 +866,7 @@ public class PodCommsSession {
     public func resumeBasal(schedule: BasalSchedule, scheduleOffset: TimeInterval, acknowledgementBeep: Bool = false, programReminderInterval: TimeInterval = 0) throws -> StatusResponse {
 
         if podState.unacknowledgedCommand != nil {
-            try resolveUnacknowledgedCommand()
+            try tryToResolvePendingCommand()
         }
 
         let status = try setBasalSchedule(schedule: schedule, scheduleOffset: scheduleOffset, acknowledgementBeep: acknowledgementBeep, programReminderInterval: programReminderInterval)
@@ -1059,7 +1059,7 @@ public class PodCommsSession {
             if podState.unacknowledgedCommand != nil {
                 // Try to resolve the unacknowledged command now as DeactivatePodCommand
                 // destroys any chance of correctly handling the unacknowledged command.
-                try? resolveUnacknowledgedCommand()
+                try? tryToResolvePendingCommand()
             }
 
             let deactivatePod = DeactivatePodCommand(nonce: podState.currentNonce)
@@ -1082,7 +1082,7 @@ public class PodCommsSession {
     public func acknowledgeAlerts(alerts: AlertSet, beepBlock: MessageBlock? = nil) throws -> AlertSet {
 
         if podState.unacknowledgedCommand != nil {
-            try resolveUnacknowledgedCommand()
+            try tryToResolvePendingCommand()
         }
 
         let cmd = AcknowledgeAlertCommand(nonce: podState.currentNonce, alerts: alerts)

--- a/OmniKit/PumpManager/PodState.swift
+++ b/OmniKit/PumpManager/PodState.swift
@@ -300,7 +300,7 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         if deliveryStatus.tempBasalRunning && unfinalizedTempBasal == nil { // active temp basal that we aren't tracking
             // unfinalizedTempBasal = UnfinalizedDose(tempBasalRate: 0, startTime: Date(), duration: .minutes(30), isHighTemp: false, scheduledCertainty: .certain, insulinType: insulinType)
         }
-        if deliveryStatus != .suspended && isSuspended { // active basal that we aren't tracking
+        if !deliveryStatus.suspended && isSuspended { // active basal that we aren't tracking
             let resumeStartTime = Date()
             suspendState = .resumed(resumeStartTime)
             unfinalizedResume = UnfinalizedDose(resumeStartTime: resumeStartTime, scheduledCertainty: .certain, insulinType: insulinType)
@@ -555,7 +555,7 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
             "* expiresAt: \(String(reflecting: expiresAt))",
             "* podTime: \(podTime.timeIntervalStr)",
             "* podTimeUpdated: \(String(reflecting: podTimeUpdated))",
-            "* setupUnitsDelivered: \(String(reflecting: setupUnitsDelivered))",
+            "* setupUnitsDelivered: \(setupUnitsDelivered == nil ? "?" : setupUnitsDelivered!.twoDecimals) U",
             "* piVersion: \(piVersion)",
             "* pmVersion: \(pmVersion)",
             "* lot: \(lot)",
@@ -568,6 +568,8 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
             "* unfinalizedResume: \(String(describing: unfinalizedResume))",
             "* finalizedDoses: \(String(describing: finalizedDoses))",
             "* activeAlertsSlots: \(alertSetString(alertSet: activeAlertSlots))",
+            "* delivered: \(lastInsulinMeasurements == nil ? "?" : lastInsulinMeasurements!.delivered.twoDecimals) U",
+            "* reservoirLevel: \(lastInsulinMeasurements == nil || lastInsulinMeasurements!.reservoirLevel == nil || lastInsulinMeasurements!.reservoirLevel == Pod.reservoirLevelAboveThresholdMagicNumber ? "50+" : lastInsulinMeasurements!.reservoirLevel!.twoDecimals) U",
             "* messageTransportState: \(String(describing: messageTransportState))",
             "* setupProgress: \(setupProgress)",
             "* primeFinishTime: \(String(describing: primeFinishTime))",

--- a/OmniKitUI/PumpManager/OmniPodPumpManager+UI.swift
+++ b/OmniKitUI/PumpManager/OmniPodPumpManager+UI.swift
@@ -47,6 +47,24 @@ extension OmnipodPumpManager: PumpManagerUI {
 
 }
 
+public enum OmniKitStatusBadge: DeviceStatusBadge {
+    case timeSyncNeeded
+
+    public var image: UIImage? {
+        switch self {
+        case .timeSyncNeeded:
+            return UIImage(systemName: "clock.fill")
+        }
+    }
+
+    public var state: DeviceStatusBadgeState {
+        switch self {
+        case .timeSyncNeeded:
+            return .warning
+        }
+    }
+}
+
 // MARK: - PumpStatusIndicator
 extension OmnipodPumpManager {
     public var pumpStatusHighlight: DeviceStatusHighlight? {
@@ -58,7 +76,10 @@ extension OmnipodPumpManager {
     }
     
     public var pumpStatusBadge: DeviceStatusBadge? {
-        return nil
+        if isClockOffset {
+            return OmniKitStatusBadge.timeSyncNeeded
+        } else {
+            return nil
+        }
     }
-
 }


### PR DESCRIPTION
## Purpose

Bring in improvements added to the main branch since the tidepool-merge branch was first pushed to LoopKit

## Test

Start with a local clone using LoopWorkspace `tidepool-merge` branch:

* Perform a test merge of main into tidepool-merge for OmniKit in that local clone
* Open Xcode workspace and build with modified OmniKit

Confirmed that Eros pod can be selected but do not actually connect to a pod.