### PR TITLE
Fixes to handle unacknowledged command with pod faults correctly

### DIFF
--- a/OmniKit/OmnipodCommon/UnfinalizedDose.swift
+++ b/OmniKit/OmnipodCommon/UnfinalizedDose.swift
@@ -155,7 +155,10 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         case .bolus:
             let oldRate = rate
             if let remaining = remaining {
-                units = units - remaining
+                // Guard against negative bolus if incorrectly called a 2nd time or with a bad remaining
+                if remaining <= units {
+                    units -= remaining
+                }
             } else {
                 units = oldRate * newDuration.hours
             }


### PR DESCRIPTION
## Purpose:

Fix the corner case where a pod fault is treated as an unacknowledged command during an interrupted bolus and the undelivered insulin is subtracted twice from the original bolus amount.

This was reported for both Trio and Loop (the two apps use a common set of OmniBLE and OmniKit modules):
* [Trio in Issue 627](https://github.com/nightscout/Trio/issues/627)
* [Loop in Issue 2232](https://github.com/LoopKit/Loop/issues/2322)

## Method

* Recognize that getting a fault return from a pod, 0x202, should not be treated the same as not getting a podStatus return, 0x1d return. In other words, this is not an unacknowledged command.

* Make sure the interrupted bolus is handled in only one place.

* Ensure that the delivered insulin can never be negative.

## Test

This was tested by @itsmojo who provided the code modification. Once the PR are in place, this will be tested again.