### PR TITLE
Fixes for various subtle resume and suspend events issues

### DIFF
--- a/OmniKit/PumpManager/PodCommsSession.swift
+++ b/OmniKit/PumpManager/PodCommsSession.swift
@@ -393,7 +393,6 @@ public class PodCommsSession {
             let status = try getStatus()
             if status.podProgressStatus == .basalInitialized {
                 podState.setupProgress = .initialBasalScheduleSet
-                podState.finalizedDoses.append(UnfinalizedDose(resumeStartTime: currentDate, scheduledCertainty: .certain, insulinType: podState.insulinType))
                 return
             }
         }
@@ -402,7 +401,6 @@ public class PodCommsSession {
         // Set basal schedule
         let _ = try setBasalSchedule(schedule: basalSchedule, scheduleOffset: scheduleOffset)
         podState.setupProgress = .initialBasalScheduleSet
-        podState.finalizedDoses.append(UnfinalizedDose(resumeStartTime: currentDate, scheduledCertainty: .certain, insulinType: podState.insulinType))
     }
 
     //


### PR DESCRIPTION
+ Remove incorrect resume event creation in programInitialBasalSchedule()
+ Finalize resume & suspend "doses" independently on matching delivery status
+ Update dosesToStore var to no longer include now unneeded unfinalizedSuspend
+ Use date instead of Date() in updateDeliveryStatus() for consistency
+ Use self.lastSync instead of lastSync for better clarity & consistency
+ Update basalDeliveryState to treat a non-active pod just like no pod