### PR TITLE
Correctly handle dosing & pump events on discard (Loop issue #2382)

### DIFF
--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -708,7 +708,9 @@ extension OmnipodPumpManager {
             state.updatePodStateFromPodComms(nil)
         }
 
-        podComms.forgetPod()
+        self.podComms.handleDiscardedPodDosing(podTime: podTime, reservoirLevel: reservoirLevel?.rawValue)
+
+        self.podComms.forgetPod()
 
         self.resetPerPodPumpManagerState()
 


### PR DESCRIPTION
+ Invoke new PodComms handleDiscardedPodDosing() func from forgetPod()
+ Move reworked handleCancelDosing() from PodCommsSession to PodState
+ Add workaround for old pod sims that don't report a suspended pod on fault