### PR TITLE
Ensure completion closure is always called in acknowledgeAlert()

### DIFF
--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -2566,7 +2566,7 @@ extension OmnipodPumpManager: PodCommsDelegate {
 extension OmnipodPumpManager {
     public func acknowledgeAlert(alertIdentifier: Alert.AlertIdentifier, completion: @escaping (Error?) -> Void) {
         guard self.hasActivePod, !state.activeAlerts.isEmpty else {
-            log.default("@@@ Skipping acknowledge alert %{public}@ with no active pod or alerts", alertIdentifier)
+            log.default("Skipping acknowledge alert %{public}@ with no active pod or alerts", alertIdentifier)
             completion(nil)
             return
         }
@@ -2628,7 +2628,7 @@ extension OmnipodPumpManager {
         }
 
         if !found {
-            log.error("@@@ acknowledge alert %{public}@ not found!", alertIdentifier)
+            log.error("acknowledge alert %{public}@ not found!", alertIdentifier)
             completion(nil)
         }
     }


### PR DESCRIPTION
acknowledgeAlert() has some cases where its completion closure would not be called. Besides being bad form, this caused some difficulties which resulted in some controllers like iAPS & Trio having to add a hack that had to look into what should be private PM state.